### PR TITLE
chore: Add website title and metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,6 +22,11 @@ const helveticaNeue = localFont({
   variable: "--font-helvetica-neue",
 });
 
+export const metadata: Metadata = {
+  title: "Eugenio Pastoral",
+  description: "I'm Gino, a DevOps Engineer and UI Designer. Explore my portfolio for projects blending technical innovation with creative design.",
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,9 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Home - Eugenio Pastoral",
+};
+
 import Gallery from "../components/Gallery";
 import { fetchGalleryData, GalleryItem } from "../api/gallery";
 


### PR DESCRIPTION
This PR introduces the necessary configuration to set the website's title and other metadata for improved SEO and browser display.

**Changes:**
- Added a `metadata` object export to `layout.tsx` to define the global website title and description.
- Provided an example in `page.tsx` showing how to set page-specific titles that override the global title.

This ensures that the website's title is properly displayed in browser tabs/windows and helps with search engine optimization.