### PR TITLE
chore: Add push triggers to workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
       - develop
+  push:
+    branches:
+      - main
+      - develop
 
 jobs:
   build-and-test:

--- a/.github/workflows/pr-branch-validation.yaml
+++ b/.github/workflows/pr-branch-validation.yaml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
       - develop
+  push:
+    branches:
+      - main
+      - develop
+
 
 jobs:
   validate-pr-branches:


### PR DESCRIPTION
Adds `on: push` triggers to `ci.yaml` and `pr-branch-validation.yaml` workflows. This ensures the workflows also run on direct pushes to `main` and `develop` branches, in addition to pull requests.