### PR TITLE
fix: Remove push trigger from PR branch validation

### DIFF
--- a/.github/workflows/pr-branch-validation.yaml
+++ b/.github/workflows/pr-branch-validation.yaml
@@ -4,11 +4,6 @@ on:
     branches:
       - main
       - develop
-  push:
-    branches:
-      - main
-      - develop
-
 
 jobs:
   validate-pr-branches:


### PR DESCRIPTION
Removes the `on: push` trigger from `pr-branch-validation.yaml` to resolve errors occurring during merges. The workflow will now only run on `pull_request` events.
