### PR TITLE
feature: Add release workflow for Docker image publishing to GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,10 +36,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,format=long # Always tag with the full commit SHA
-            type=raw,value=beta,enable=${{ github.ref_name == 'develop' }} # Tag with 'beta' on develop branch
-            type=raw,value=stable,enable=${{ github.ref_name == 'main' }} # Tag with 'stable' on main branch
-            type=raw,value=latest,enable={{is_default_branch}} # Tag with 'latest' only on the default branch
+            type=sha,format=long
+            type=raw,value=beta,enable=${{ github.ref_name == 'develop' }}
+            type=raw,value=stable,enable=${{ github.ref_name == 'main' }}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,9 @@ env:
 
 jobs:
   publish-docker-image:
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,8 +33,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,format=long # Tag with the full commit SHA
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=long # Always tag with the full commit SHA
+            type=raw,value=beta,enable=${{ github.ref_name == 'develop' }} # Tag with 'beta' on develop branch
+            type=raw,value=stable,enable=${{ github.ref_name == 'main' }} # Tag with 'stable' on main branch
+            type=raw,value=latest,enable={{is_default_branch}} # Tag with 'latest' only on the default branch
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Normalise IMAGE_NAME
+        run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,46 @@
+name: Release & Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,format=long # Tag with the full commit SHA
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow (`.github/workflows/release.yaml`) to automate the building and publishing of the Docker image to GitHub Container Registry (GHCR).

The workflow is triggered on pushes to the `main` and `develop` branches (typically after a PR merge).

Key features:
- Logs into GHCR using `GITHUB_TOKEN`.
- Builds the Docker image using the existing `Dockerfile`.
- Tags the image with:
    - The full commit SHA (e.g., `sha-abcdef123`).
    - `beta` when pushed to the `develop` branch.
    - `stable` when pushed to the `main` branch.
    - `latest` when pushed to the `main` branch.

This automates the image release process, ensuring that up-to-date images are available in GHCR for deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced automated workflow to build and publish Docker images on pushes to main and develop branches. Images are tagged based on branch and commit for easier versioning and deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->