### PR TITLE
feature: Enable multi-platform Docker builds (amd64, arm64)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: 'linux/amd64,linux/arm64'
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -49,5 +55,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          install: true
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This PR enhances the `Release & Publish Docker Image` GitHub Actions workflow (`.github/workflows/release.yaml`) to support multi-platform Docker image builds.

Previously, the workflow only built images for a single architecture. With this update, the workflow will now build and push Docker images compatible with both `linux/amd64` (x86) and `linux/arm64` architectures.

Key changes include:
- **`docker/setup-qemu-action`**: Added to enable emulation for building different architectures on a single runner.
- **`docker/setup-buildx-action`**: Added to set up Docker Buildx, which is required for multi-platform builds.
- **`platforms: linux/amd64,linux/arm64`**: Configured in the `docker/build-push-action` to explicitly target both architectures.

This improvement ensures our Docker images are more versatile and can be deployed efficiently across a wider range of environments, including ARM-based systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the release process to produce Docker images compatible with both AMD64 and ARM64 platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->