### PR TITLE
chore: Remove push trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,10 +4,6 @@ on:
     branches:
       - main
       - develop
-  push:
-    branches:
-      - main
-      - develop
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This PR updates the CI workflow to remove the `on: push` trigger.

Previously, the workflow would run on every push to the `main` and `develop` branches. With this change, the CI workflow will now only trigger on pull requests to `main` and `develop`.

This adjustment helps to reduce unnecessary CI runs for every commit pushed directly to these branches, streamlining the development process by focusing CI efforts on code integrations via pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to run only on pull requests targeting main and develop branches, no longer running on direct pushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->