### PR TITLE
fix: Correct Next.js config file extension in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY --from=builder --chown=appuser:appgroup /app/.next ./.next
 COPY --from=builder --chown=appuser:appgroup /app/node_modules ./node_modules
 COPY --from=builder --chown=appuser:appgroup /app/public ./public
 COPY --from=builder --chown=appuser:appgroup /app/package.json ./package.json
-COPY --from=builder --chown=appuser:appgroup /app/next.config.js ./next.config.js
+COPY --from=builder --chown=appuser:appgroup /app/next.config.ts ./next.config.ts
 
 # Expose application port
 EXPOSE 3000


### PR DESCRIPTION
This PR corrects the file extension for the Next.js configuration file copied in the Dockerfile's runner stage.

Previously, the Dockerfile was attempting to copy `next.config.js`. This has been updated to `next.config.ts` to correctly reflect the TypeScript configuration file used in the project. This ensures the Next.js application has access to its runtime configuration when deployed.