### PR TITLE
fix: Animate Navbar slide-in after intro animation

### DIFF
--- a/src/app/ClientIntroHandler.tsx
+++ b/src/app/ClientIntroHandler.tsx
@@ -80,8 +80,10 @@ export default function ClientIntroHandler({
           <MobileComingSoon />
         </div>
       ) : (
-        <div
-          className={`
+        <>
+          <Navbar />
+          <div
+            className={`
             antialiased flex flex-col min-h-screen min-w-[1024px]
             transition-transform duration-500 ease-in-out
             ${
@@ -91,12 +93,12 @@ export default function ClientIntroHandler({
             }
             ${!showIntro ? "delay-100" : ""}
           `}
-        >
-          <Navbar />
-          <main className="flex flex-grow flex-col overflow-y-auto overflow-x-hidden pt-[5.5rem]">
-            <div className="mx-auto max-w-[1440px] w-full">{children}</div>
-          </main>
-        </div>
+          >
+            <main className="flex flex-grow flex-col overflow-y-auto overflow-x-hidden pt-[5.5rem]">
+              <div className="mx-auto max-w-[1440px] w-full">{children}</div>
+            </main>
+          </div>
+        </>
       )}
     </>
   );

--- a/src/app/ClientIntroHandler.tsx
+++ b/src/app/ClientIntroHandler.tsx
@@ -17,6 +17,7 @@ export default function ClientIntroHandler({
   const [showIntro, setShowIntro] = useState(true);
   const [contentPrep, setContentPrep] = useState(false);
   const [shouldShowMobileUI, setShouldShowMobileUI] = useState(false);
+  const [showNavbar, setShowNavbar] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -49,6 +50,7 @@ export default function ClientIntroHandler({
 
   const handleAnimationComplete = () => {
     setShowIntro(false);
+    setShowNavbar(true);
 
     if (!shouldShowMobileUI) {
       document.body.style.overflow = "";
@@ -81,18 +83,25 @@ export default function ClientIntroHandler({
         </div>
       ) : (
         <>
-          <Navbar />
+          <Navbar
+            className={`
+              fixed top-0 left-0 w-full z-50
+              transition-transform duration-700 ease-in-out
+              ${showNavbar ? "translate-y-0" : "-translate-y-full"}
+            `}
+          />
+
           <div
             className={`
-            antialiased flex flex-col min-h-screen min-w-[1024px]
-            transition-transform duration-500 ease-in-out
-            ${
-              showIntro && contentPrep
-                ? "translate-y-full opacity-0 pointer-events-none"
-                : "translate-y-0 opacity-100"
-            }
-            ${!showIntro ? "delay-100" : ""}
-          `}
+              antialiased flex flex-col min-h-screen min-w-[1024px]
+              transition-opacity duration-500 ease-in-out
+              ${
+                showIntro && contentPrep
+                  ? "opacity-0 pointer-events-none"
+                  : "opacity-100"
+              }
+              ${!showIntro ? "delay-100" : ""}
+            `}
           >
             <main className="flex flex-grow flex-col overflow-y-auto overflow-x-hidden pt-[5.5rem]">
               <div className="mx-auto max-w-[1440px] w-full">{children}</div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import Button from "./Button";
+interface NavbarProps {
+  className?: string;
+}
 
-interface NavbarProps {}
-
-const Navbar: React.FC<NavbarProps> = () => {
+const Navbar: React.FC<NavbarProps> = ({ className }) => {
   return (
-    <div className="p-4 flex justify-between fixed top-0 left-0 w-full z-50">
+    <div className={`p-4 flex justify-between ${className}`}>
       <Button
         title="Eugenio Pastoral"
         subtitle="DevOps Engineer & UI Designer"


### PR DESCRIPTION
This PR adds a smooth slide-in animation for the Navbar, making it appear from the top and remain fixed once the intro animation finishes.

**Key changes:**
- `ClientIntroHandler.tsx`: Manages the Navbar's animation state (`showNavbar`) and passes animation classes.
- `Navbar.tsx`: Now accepts a `className` prop to apply dynamic animation styles.
- Main content is now correctly padded to avoid overlap with the fixed Navbar.

This improves the initial user experience with a polished transition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The navigation bar now appears with a smooth slide-down animation after the intro animation completes, enhancing the user experience.

* **Refactor**
  * Improved separation and animation of the navigation bar and main content for non-mobile users, resulting in smoother and more independent transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->