### PR TITLE
feature: Automate Helm chart image tag update

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -66,3 +68,50 @@ jobs:
             GH_API_TOKEN=${{ secrets.GH_API_TOKEN }}
           build-args: |
             GH_USERNAME=${{ secrets.GH_USERNAME }}
+
+  update-helm-chart:
+    needs: publish-docker-image
+    if: github.ref_name == 'main' || github.ref_name == 'develop'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Helm Charts repository
+        uses: actions/checkout@v4
+        with:
+          repository: achrovisual/hl-k3s
+          token: ${{ secrets.HELM_REPO_PAT }}
+          path: helm-charts
+
+      - name: Install yq
+        run: sudo snap install yq
+
+      - name: Extract Image Tag
+        id: get_image_tag
+        run: |
+          IMAGE_TAG=$(echo "${{ needs.publish-docker-image.outputs.tags }}" | head -n 1)
+          echo "Extracted Image Tag: $IMAGE_TAG"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"
+
+      - name: Update Helm chart image tag
+        working-directory: ./helm-charts
+        run: |
+          HELM_CHART_PATH="charts/private/portfolio"
+          IMAGE_TAG="${{ env.IMAGE_TAG }}"
+
+          echo "Updating $HELM_CHART_PATH/values.yaml with image tag: $IMAGE_TAG"
+          yq e ".image.tag = \"$IMAGE_TAG\"" -i "$HELM_CHART_PATH/values.yaml"
+
+          echo "--- Updated values.yaml content ---"
+          cat "$HELM_CHART_PATH/values.yaml"
+          echo "-----------------------------------"
+
+      - name: Commit and push changes
+        working-directory: ./helm-charts
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git add .
+          git diff --staged --exit-code || (git commit -m "Update portfolio image to ${{ env.IMAGE_TAG }}" && git push)
+        env:
+          GITHUB_TOKEN: ${{ secrets.HELM_REPO_PAT }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,8 @@ jobs:
       - name: Extract Image Tag
         id: get_image_tag
         run: |
-          IMAGE_TAG=$(echo "${{ needs.publish-docker-image.outputs.tags }}" | head -n 1)
+          IMAGE_TAG=$(printf '%s\n' "${{ needs.publish-docker-image.outputs.tags }}" \
+            | head -n 1 | awk -F':' '{print $NF}')
           echo "Extracted Image Tag: $IMAGE_TAG"
           echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,7 +115,7 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git add .
+          git add charts/private/portfolio/values.yaml
           git diff --staged --exit-code || (git commit -m "Update portfolio image to ${{ env.IMAGE_TAG }}" && git push)
         env:
           GITHUB_TOKEN: ${{ secrets.HELM_REPO_PAT }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,7 +84,10 @@ jobs:
           path: helm-charts
 
       - name: Install yq
-        run: sudo snap install yq
+        run: |
+          YQ_VERSION="v4.44.1"
+          curl -L "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
 
       - name: Extract Image Tag
         id: get_image_tag


### PR DESCRIPTION
This PR introduces a new job to the release workflow that automatically updates the `image.tag` in the `portfolio` Helm chart within the `hl-k3s` repository.

This ensures that new Docker image releases (based on SHA tags) are automatically reflected in the Helm chart, streamlining deployments via Argo CD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automation to update the Helm chart's image tag after publishing a Docker image, streamlining deployment processes on main and develop branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->