### PR TITLE
fix: Preserve hero line whitespace and add fluid clamp text scaling

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -69,7 +69,7 @@ export default function RootLayout({
     <html lang="en" className={`${lexend.variable} ${sourceSerif.variable}`}>
       <body className="h-screen flex flex-col overflow-hidden font-sans">
         <Header />
-        <main className="flex-1 overflow-y-auto snap-y snap-mandatory">
+        <main className="flex-1 overflow-y-auto overflow-x-hidden snap-y snap-mandatory">
           <div className="max-w-7xl mx-auto py-8 h-full flex flex-col">
             {children}
           </div>

--- a/src/components/layout/section.tsx
+++ b/src/components/layout/section.tsx
@@ -6,7 +6,7 @@ interface SectionProps {
 export default function Section({ children, className = "" }: SectionProps) {
   return (
     <section
-      className={`h-full w-full snap-start flex items-stretch px-8 ${className}`}
+      className={`h-full w-full snap-start flex items-stretch px-4 md:px-8 ${className}`}
     >
       {children}
     </section>

--- a/src/components/sections/hero.tsx
+++ b/src/components/sections/hero.tsx
@@ -192,7 +192,7 @@ export default function Hero() {
                     {((isCurrentLine && !isDone) || (isLastLine && isDone)) && (
                       <span
                         className={`inline-block w-[3px] h-[1em] bg-foreground ml-1 ${
-                          isDone ? "animate-pulse" : ""
+                          isDone ? "animate-cursor-blink" : ""
                         }`}
                         aria-hidden="true"
                       />

--- a/src/components/sections/hero.tsx
+++ b/src/components/sections/hero.tsx
@@ -23,23 +23,31 @@ import {
   Terraform,
 } from "@boxicons/react";
 
-const SEGMENTS: Segment[] = [
-  { text: "Gino is a DevOps engineer and UI designer who builds " },
-  { text: "reliable platforms", underline: true },
-  { text: ", " },
-  { text: "bare-metal networks", underline: true },
-  { text: ", and " },
-  { text: "intuitive digital experiences", underline: true },
-  { text: "." },
+// Structured into 4 strict lines
+const SEGMENT_LINES: Segment[][] = [
+  [{ text: "Gino is a DevOps engineer and UI" }],
+  [
+    { text: "designer who builds " },
+    { text: "reliable platforms", underline: true },
+    { text: "," },
+  ],
+  [
+    { text: "bare-metal networks", underline: true },
+    { text: ", and " },
+    { text: "intuitive digital", underline: true },
+  ],
+  [{ text: "experiences", underline: true }, { text: "." }],
 ];
 
-const FULL_TEXT = SEGMENTS.map((s) => s.text).join("");
+const FULL_TEXT = SEGMENT_LINES.flatMap((line) => line)
+  .map((s) => s.text)
+  .join("");
 
-function renderSegments(
-  segments: Segment[],
+function renderLineSegments(
+  line: Segment[],
   remainingRef: { current: number },
 ) {
-  return segments.map((segment, i) => {
+  return line.map((segment, i) => {
     const visibleChars = Math.max(
       0,
       Math.min(segment.text.length, remainingRef.current),
@@ -133,6 +141,8 @@ const DEFAULT_MARQUEE_TEXT =
 export default function Hero() {
   const displayed = useTypewriter(FULL_TEXT, 30);
   const isDone = displayed.length === FULL_TEXT.length;
+
+  const invisibleRemaining = { current: FULL_TEXT.length };
   const animatedRemaining = { current: displayed.length };
 
   const [hoveredText, setHoveredText] = useState<string | null>(null);
@@ -146,28 +156,50 @@ export default function Hero() {
 
   return (
     <Section>
-      <div className="flex flex-col justify-between">
+      <div className="flex flex-col justify-between w-full h-full">
         <div className="flex flex-col gap-2">
           {/* Invisible full-text layer — reserves final height/line-wrapping upfront */}
           <div
             className="font-serif text-2xl md:text-6xl leading-tight relative"
             aria-hidden="true"
           >
-            <span className="invisible">
-              {SEGMENTS.map((s, i) => (
-                <span key={i} className={s.underline ? "underline" : undefined}>
-                  {s.text}
-                </span>
+            <div className="invisible">
+              {SEGMENT_LINES.map((line, lineIndex) => (
+                <div key={lineIndex} className="whitespace-nowrap flex shrink">
+                  {renderLineSegments(line, invisibleRemaining)}
+                </div>
               ))}
-            </span>
+            </div>
 
             {/* Animated layer — absolutely positioned over the reserved space */}
             <h1 className="absolute inset-0 font-serif text-2xl md:text-6xl leading-tight">
-              {renderSegments(SEGMENTS, animatedRemaining)}
-              <span
-                className={`inline-block w-[3px] h-[1em] bg-foreground ml-1 align-middle ${isDone ? "animate-pulse" : ""}`}
-                aria-hidden="true"
-              />
+              {SEGMENT_LINES.map((line, lineIndex) => {
+                const lineTextLength = line.reduce(
+                  (acc, s) => acc + s.text.length,
+                  0,
+                );
+                const isCurrentLine =
+                  animatedRemaining.current > 0 &&
+                  animatedRemaining.current <= lineTextLength;
+                const isLastLine = lineIndex === SEGMENT_LINES.length - 1;
+
+                return (
+                  <div
+                    key={lineIndex}
+                    className="whitespace-nowrap flex shrink"
+                  >
+                    {renderLineSegments(line, animatedRemaining)}
+                    {((isCurrentLine && !isDone) || (isLastLine && isDone)) && (
+                      <span
+                        className={`inline-block w-[3px] h-[1em] bg-foreground ml-1 align-middle ${
+                          isDone ? "animate-pulse" : ""
+                        }`}
+                        aria-hidden="true"
+                      />
+                    )}
+                  </div>
+                );
+              })}
             </h1>
           </div>
 
@@ -201,7 +233,7 @@ export default function Hero() {
 
         {/* Tech marquee — breaks out of the max-w-6xl container to span the full viewport */}
         <div className="relative left-1/2 right-1/2 -mx-[50vw] w-screen">
-          <p className="max-w-7xl mx-auto mb-4 px-4 px-8 text-sm md:text-base text-foreground">
+          <p className="max-w-7xl mx-auto mb-4 px-4 md:px-8 text-sm md:text-base text-foreground">
             {hoveredText ?? DEFAULT_MARQUEE_TEXT}
           </p>
 

--- a/src/components/sections/hero.tsx
+++ b/src/components/sections/hero.tsx
@@ -186,12 +186,12 @@ export default function Hero() {
                 return (
                   <div
                     key={lineIndex}
-                    className="whitespace-nowrap flex shrink"
+                    className="whitespace-nowrap flex items-center shrink"
                   >
                     {renderLineSegments(line, animatedRemaining)}
                     {((isCurrentLine && !isDone) || (isLastLine && isDone)) && (
                       <span
-                        className={`inline-block w-[3px] h-[1em] bg-foreground ml-1 align-middle ${
+                        className={`inline-block w-[3px] h-[1em] bg-foreground ml-1 ${
                           isDone ? "animate-pulse" : ""
                         }`}
                         aria-hidden="true"

--- a/src/components/sections/hero.tsx
+++ b/src/components/sections/hero.tsx
@@ -160,19 +160,22 @@ export default function Hero() {
         <div className="flex flex-col gap-2">
           {/* Invisible full-text layer — reserves final height/line-wrapping upfront */}
           <div
-            className="font-serif text-2xl md:text-6xl leading-tight relative"
+            className="font-serif leading-tight relative"
+            style={{ fontSize: "clamp(1.1rem, 4vw, 3rem)" }}
             aria-hidden="true"
           >
             <div className="invisible">
               {SEGMENT_LINES.map((line, lineIndex) => (
-                <div key={lineIndex} className="whitespace-nowrap flex shrink">
+                <div key={lineIndex} className="whitespace-pre flex shrink">
                   {renderLineSegments(line, invisibleRemaining)}
                 </div>
               ))}
             </div>
 
-            {/* Animated layer — absolutely positioned over the reserved space */}
-            <h1 className="absolute inset-0 font-serif text-2xl md:text-6xl leading-tight">
+            <h1
+              className="absolute inset-0 font-serif leading-tight"
+              style={{ fontSize: "clamp(1.1rem, 4vw, 3rem)" }}
+            >
               {SEGMENT_LINES.map((line, lineIndex) => {
                 const lineTextLength = line.reduce(
                   (acc, s) => acc + s.text.length,
@@ -186,7 +189,7 @@ export default function Hero() {
                 return (
                   <div
                     key={lineIndex}
-                    className="whitespace-nowrap flex items-center shrink"
+                    className="whitespace-pre flex items-center shrink"
                   >
                     {renderLineSegments(line, animatedRemaining)}
                     {((isCurrentLine && !isDone) || (isLastLine && isDone)) && (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -71,3 +71,27 @@ body {
     animation: none;
   }
 }
+
+/* Cursor Blink Keyframes & Animation */
+@keyframes cursor-blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  51%,
+  100% {
+    opacity: 0;
+  }
+}
+
+.animate-cursor-blink {
+  -webkit-animation: cursor-blink 1s step-end infinite;
+  animation: cursor-blink 1s step-end infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-cursor-blink {
+    -webkit-animation: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the hero section’s typewriter animation with responsive text sizing, line-aware cursor placement, and a blinking cursor after completion.
  - Added reduced-motion support for cursor animation.

- **Bug Fixes**
  - Prevented unintended horizontal scrolling.
  - Improved responsive spacing across sections and marquee content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->